### PR TITLE
Adding CCNSE course

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@
 
 ## Trainings
 
+##### **Practical DevSecOps**
+* Certified Cloud Native Security Expert - [Training](https://www.practical-devsecops.com/certified-cloud-native-security-expert)
+
 ##### **PromLabs**
 * Introduction to Prometheus - [Training](https://training.promlabs.com/training/introduction-to-prometheus/training-overview/introduction)
 


### PR DESCRIPTION
Adding the CCNSE course from the company Practical DevSecOps to the README.md file. 

Course link: https://www.practical-devsecops.com/certified-cloud-native-security-expert/